### PR TITLE
feat: enhance detection of dependencies between threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `-s/-ssh` to use a specific shell command to execute jcmds and more
 
+## [0.5.5] - 2026-04-02
+
+### Added
+- `dependency-graph` with proper detection of dependencies between threads
+
 ## [0.5.4] - 2026-03-19
 
 ### Changed

--- a/src/main/java/me/bechberger/jstall/analyzer/impl/DependencyGraphAnalyzer.java
+++ b/src/main/java/me/bechberger/jstall/analyzer/impl/DependencyGraphAnalyzer.java
@@ -10,13 +10,40 @@ import me.bechberger.jthreaddump.model.LockInfo;
 import me.bechberger.jthreaddump.model.ThreadDump;
 import me.bechberger.jthreaddump.model.ThreadInfo;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
- * Analyzes thread dependencies by showing which threads wait on locks held by other threads.
- * Creates a dependency graph showing the waiting relationships.
+ * Analyzes thread dependencies across all dumps, building BFS dependency graphs per dump,
+ * aggregating by root thread and rendering tree output showing
+ * potential bottleneck roots with their blocked thread trees.
  */
 public class DependencyGraphAnalyzer extends BaseAnalyzer {
+
+    record LockDependencies(Map<ThreadInfo, Set<String>> owners, Map<ThreadInfo, Set<String>> waiters) {
+    }
+
+    record DependencyGraph(ThreadInfo root, Instant timestamp, Map<Long, ThreadInfo> nodes,
+                           Map<Long, List<Long>> adjacency) {
+        int size() {
+            return nodes.size();
+        }
+
+        List<ThreadInfo> children(ThreadInfo parent) {
+            List<Long> childIds = adjacency.getOrDefault(parent.threadId(), List.of());
+            List<ThreadInfo> result = new ArrayList<>();
+            for (Long id : childIds) {
+                ThreadInfo t = nodes.get(id);
+                if (t != null) result.add(t);
+            }
+            return result;
+        }
+    }
+
+    record RootGroup(ThreadInfo root, List<DependencyGraph> graphs) {
+    }
 
     @Override
     public String name() {
@@ -39,45 +66,399 @@ public class DependencyGraphAnalyzer extends BaseAnalyzer {
         if (dumps.isEmpty()) {
             return AnalyzerResult.nothing();
         }
-        // Use the latest dump for dependency analysis
-        ThreadDump latestDump = dumps.get(dumps.size() - 1);
 
-        // Build lock ownership map
-        Map<String, ThreadInfo> lockOwners = new HashMap<>();
-        Map<ThreadInfo, String> threadWaitingOn = new HashMap<>();
+        List<DependencyGraph> allGraphs = new ArrayList<>();
+        for (ThreadDump dump : dumps) {
+            LockDependencies dependencies = buildLockDependencies(dump.threads());
+            List<ThreadInfo> roots = findRootThreads(dependencies);
+            Instant ts = dump.timestamp();
+            for (ThreadInfo root : roots) {
+                DependencyGraph graph = buildGraph(dependencies, root, ts);
+                if (graph.size() > 1) { // Only include graphs with blocked threads (more than 1 dependency)
+                    allGraphs.add(graph);
+                }
+            }
+        }
 
-        for (ThreadInfo thread : latestDump.threads()) {
-            // Track locks held by this thread
-            if (thread.locks() != null) {
-                for (LockInfo lock : thread.locks()) {
-                    if (lock.isLocked()) {
-                        lockOwners.put(lock.lockId(), thread);
+        if (allGraphs.isEmpty()) {
+            return AnalyzerResult.nothing();
+        }
+
+        List<RootGroup> groups = aggregateGraphs(allGraphs);
+
+        Map<Long, Instant> firstSeenTimes = computeFirstSeenTimes(groups);
+
+        Map<String, Integer> heavyNodes = findHeavyNodes(groups);
+
+        Map<Long, Set<Long>> disappearingByRoot = new HashMap<>();
+        Map<Long, DependencyGraph> mergedGraphs = new HashMap<>();
+        for (RootGroup group : groups) {
+            DependencyGraph biggest = findBiggestGraph(group);
+            Set<Long> disappeared = findDisappearingNodes(group, biggest);
+            disappearingByRoot.put(group.root().threadId(), disappeared);
+            mergedGraphs.put(group.root().threadId(), mergeDisappearingNodes(biggest, group, disappeared));
+        }
+
+        return AnalyzerResult.ok(formatDependencyTree(groups, mergedGraphs, disappearingByRoot,
+                firstSeenTimes, heavyNodes));
+    }
+
+    LockDependencies buildLockDependencies(List<ThreadInfo> threads) {
+        Map<ThreadInfo, Set<String>> owners = new HashMap<>();
+        Map<ThreadInfo, Set<String>> waiters = new HashMap<>();
+
+        for (ThreadInfo thread : threads) {
+            for (LockInfo lock : thread.locks()) {
+                switch (lock.operation()) {
+                    case LOCKED -> owners.computeIfAbsent(thread, k -> new HashSet<>()).add(lock.lockId());
+                    case WAITING_TO_LOCK, WAITING_ON, PARKING, ELIMINATED ->
+                            waiters.computeIfAbsent(thread, k -> new HashSet<>()).add(lock.lockId());
+                }
+            }
+        }
+        return new LockDependencies(owners, waiters);
+    }
+
+    List<ThreadInfo> findRootThreads(LockDependencies dependencies) {
+        return dependencies.owners().keySet().stream()
+                .filter(owner -> !dependencies.waiters().containsKey(owner))
+                .toList();
+    }
+
+    DependencyGraph buildGraph(LockDependencies dependencies, ThreadInfo root, Instant timestamp) {
+        Set<Link> links = buildLinks(dependencies);
+
+        Map<Long, ThreadInfo> nodes = new HashMap<>();
+        Map<Long, List<Long>> adjacency = new HashMap<>();
+
+        Set<Long> visited = new HashSet<>();
+        Queue<ThreadInfo> queue = new ArrayDeque<>();
+        queue.add(root);
+        visited.add(root.threadId());
+
+        while (!queue.isEmpty()) {
+            ThreadInfo current = queue.poll();
+            nodes.put(current.threadId(), current);
+            adjacency.putIfAbsent(current.threadId(), new ArrayList<>());
+
+            for (Link link : links) {
+                if (Objects.equals(link.owner.threadId(), current.threadId()) && visited.add(link.waiter.threadId())) {
+                    queue.add(link.waiter);
+                    adjacency.computeIfAbsent(current.threadId(), k -> new ArrayList<>())
+                            .add(link.waiter.threadId());
+                }
+            }
+        }
+
+        return new DependencyGraph(root, timestamp, nodes, adjacency);
+    }
+
+    private record Link(ThreadInfo owner, ThreadInfo waiter) {
+    }
+
+    private Set<Link> buildLinks(LockDependencies dependencies) {
+        Map<String, Set<ThreadInfo>> waitersByResource = new HashMap<>();
+        dependencies.waiters().forEach((thread, resources) -> {
+            for (String resource : resources) {
+                waitersByResource.computeIfAbsent(resource, k -> new HashSet<>()).add(thread);
+            }
+        });
+
+        Set<Link> links = new LinkedHashSet<>();
+        dependencies.owners().forEach((owner, resources) -> {
+            for (String resource : resources) {
+                Set<ThreadInfo> waiting = waitersByResource.get(resource);
+                if (waiting != null) {
+                    for (ThreadInfo waiter : waiting) {
+                        links.add(new Link(owner, waiter));
+                    }
+                }
+            }
+        });
+        return links;
+    }
+
+    List<RootGroup> aggregateGraphs(List<DependencyGraph> allGraphs) {
+        Map<Long, RootGroup> byRootId = new LinkedHashMap<>();
+
+        for (DependencyGraph graph : allGraphs) {
+            long rootId = graph.root().threadId();
+            byRootId.computeIfAbsent(rootId, k -> new RootGroup(graph.root(), new ArrayList<>()))
+                    .graphs().add(graph);
+        }
+
+        return byRootId.values().stream()
+                .sorted(Comparator.comparingInt((RootGroup rg) -> rg.graphs().size()).reversed())
+                .toList();
+    }
+
+    Map<Long, Instant> computeFirstSeenTimes(List<RootGroup> groups) {
+        Map<Long, Instant> firstSeen = new HashMap<>();
+
+        for (RootGroup group : groups) {
+            List<DependencyGraph> sorted = group.graphs().stream()
+                    .sorted(Comparator.comparing(DependencyGraph::timestamp, Comparator.nullsLast(Comparator.naturalOrder())))
+                    .toList();
+            for (DependencyGraph g : sorted) {
+                for (Long threadId : g.nodes().keySet()) {
+                    if (g.timestamp() != null) {
+                        firstSeen.putIfAbsent(threadId, g.timestamp());
+                    }
+                }
+            }
+        }
+
+        return firstSeen;
+    }
+
+    Map<String, Integer> findHeavyNodes(List<RootGroup> groups) {
+        Map<String, Integer> counts = new LinkedHashMap<>();
+
+        for (RootGroup group : groups) {
+            if (group.graphs().isEmpty()) continue;
+            DependencyGraph latest = group.graphs().get(group.graphs().size() - 1);
+            for (ThreadInfo t : latest.nodes().values()) {
+                counts.merge(t.name(), 1, Integer::sum);
+            }
+        }
+
+        counts.entrySet().removeIf(e -> e.getValue() <= 1);
+        return counts;
+    }
+
+    DependencyGraph findBiggestGraph(RootGroup group) {
+        return group.graphs().stream()
+                .max(Comparator.comparingInt(DependencyGraph::size))
+                .orElseThrow();
+    }
+
+    /**
+     * Finds threads that appear in any graph of the group but are missing in the biggest graph.
+     * These are threads that were blocked at some point but disappeared.
+     */
+    Set<Long> findDisappearingNodes(RootGroup group, DependencyGraph biggest) {
+        Set<Long> biggestNodeIds = biggest.nodes().keySet();
+        Set<Long> disappeared = new LinkedHashSet<>();
+
+        for (DependencyGraph graph : group.graphs()) {
+            for (Long threadId : graph.nodes().keySet()) {
+                if (!biggestNodeIds.contains(threadId)) {
+                    disappeared.add(threadId);
+                }
+            }
+        }
+
+        DependencyGraph latest = group.graphs().get(group.graphs().size() - 1);
+        Set<Long> latestNodeIds = latest.nodes().keySet();
+        for (DependencyGraph graph : group.graphs()) {
+            if (graph == latest) continue;
+            for (Long threadId : graph.nodes().keySet()) {
+                if (!latestNodeIds.contains(threadId) && !Objects.equals(threadId, group.root().threadId())) {
+                    disappeared.add(threadId);
+                }
+            }
+        }
+
+        return disappeared;
+    }
+
+    /**
+     * Adds the disappearing nodes to the biggest graph
+     */
+    DependencyGraph mergeDisappearingNodes(DependencyGraph biggest, RootGroup group, Set<Long> disappearedIds) {
+        if (disappearedIds.isEmpty()) {
+            return biggest;
+        }
+
+        Map<Long, ThreadInfo> mergedNodes = new HashMap<>(biggest.nodes());
+        Map<Long, List<Long>> mergedAdj = new HashMap<>();
+        for (var entry : biggest.adjacency().entrySet()) {
+            mergedAdj.put(entry.getKey(), new ArrayList<>(entry.getValue()));
+        }
+
+        long rootId = biggest.root().threadId();
+        for (Long disappearedId : disappearedIds) {
+            ThreadInfo disappeared = null;
+            for (DependencyGraph g : group.graphs()) {
+                disappeared = g.nodes().get(disappearedId);
+                if (disappeared != null) break;
+            }
+            if (disappeared == null) continue;
+
+            mergedNodes.put(disappearedId, disappeared);
+            mergedAdj.putIfAbsent(disappearedId, new ArrayList<>());
+            mergedAdj.computeIfAbsent(rootId, k -> new ArrayList<>()).add(disappearedId);
+        }
+
+        return new DependencyGraph(biggest.root(), biggest.timestamp(), mergedNodes, mergedAdj);
+    }
+
+    private String formatDependencyTree(List<RootGroup> groups,
+                                        Map<Long, DependencyGraph> mergedGraphs,
+                                        Map<Long, Set<Long>> disappearingByRoot,
+                                        Map<Long, Instant> firstSeenTimes,
+                                        Map<String, Integer> heavyNodes) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Thread Dependency Graph\n");
+        sb.append("======================\n\n");
+        sb.append("Shows which threads are waiting on locks held by other threads.\n");
+
+        Instant baseline = firstSeenTimes.values().stream()
+                .min(Comparator.naturalOrder())
+                .orElse(null);
+
+        sb.append("Found ").append(groups.size()).append(" potential bottleneck(s)\n\n");
+
+        for (RootGroup group : groups) {
+            long rootId = group.root().threadId();
+            DependencyGraph renderGraph = mergedGraphs.get(rootId);
+            Set<Long> disappeared = disappearingByRoot.getOrDefault(rootId, Set.of());
+            ThreadInfo root = renderGraph.root();
+
+            sb.append(getCategoryPrefix(root)).append(" ").append(root.name());
+            sb.append(" blocking threads in ").append(group.graphs().size()).append(" dump(s)");
+            sb.append("\n");
+
+            for (DependencyGraph g : group.graphs()) {
+                int blockedCount = g.size() - 1;
+                sb.append("  blocking ").append(blockedCount).append(" thread(s)");
+                if (baseline != null && g.timestamp() != null) {
+                    long timeDiff = Duration.between(baseline, g.timestamp()).getSeconds();
+                    if (timeDiff > 0) {
+                        sb.append(" [+").append(timeDiff).append("s]");
+                    }
+                }
+                sb.append("\n");
+            }
+            sb.append("\n");
+
+            renderTree(sb, renderGraph, root, baseline, firstSeenTimes, disappeared);
+            sb.append("\n");
+        }
+
+        if (!heavyNodes.isEmpty()) {
+            sb.append("Complex graph structure detected!\n");
+            sb.append("Threads appearing in multiple bottleneck trees:\n");
+            for (Map.Entry<String, Integer> entry : heavyNodes.entrySet()) {
+                sb.append("  ").append(entry.getKey()).append(" : ").append(entry.getValue()).append("\n");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("Summary:\n");
+        sb.append("--------\n");
+        sb.append("Bottleneck roots: ").append(groups.size()).append("\n");
+
+        int totalBlocked;
+        Set<String> allBlockedThreads = new HashSet<>();
+        for (RootGroup group : groups) {
+            DependencyGraph renderGraph = mergedGraphs.get(group.root().threadId());
+            for (ThreadInfo t : renderGraph.nodes().values()) {
+                if (!t.equals(renderGraph.root())) {
+                    allBlockedThreads.add(t.name());
+                }
+            }
+        }
+        totalBlocked = allBlockedThreads.size();
+        sb.append("Total blocked threads: ").append(totalBlocked).append("\n");
+
+        int totalDependencies = 0;
+        for (RootGroup group : groups) {
+            DependencyGraph renderGraph = mergedGraphs.get(group.root().threadId());
+            for (List<Long> children : renderGraph.adjacency().values()) {
+                totalDependencies += children.size();
+            }
+        }
+        sb.append("Total dependencies: ").append(totalDependencies).append("\n");
+
+        return sb.toString();
+    }
+
+    private void renderTree(StringBuilder sb, DependencyGraph graph, ThreadInfo root,
+                            Instant baseline, Map<Long, Instant> firstSeenTimes,
+                            Set<Long> disappearedIds) {
+        String nontrivialLocation = root.stackTrace().stream()
+                .filter(e -> !e.className().contains("java.lang"))
+                .map(e -> {
+                    if (e.fileName() != null && e.lineNumber() != null) {
+                        return e.fileName() + ":" + e.lineNumber();
+                    }
+                    return e.className() + "." + e.methodName();
+                })
+                .findFirst()
+                .orElse("");
+
+        sb.append(getCategoryPrefix(root)).append(" ").append(root.name());
+        sb.append(" (").append(graph.size() - 1).append(" blocked thread(s))");
+        if (!nontrivialLocation.isEmpty()) {
+            sb.append(" at ").append(nontrivialLocation);
+        }
+        if (root.cpuTimeSec() != null) {
+            sb.append(String.format(Locale.US, ", CPU: %.2fs", root.cpuTimeSec()));
+        }
+        sb.append("\n");
+
+        String lockIds = root.locks().stream().map(LockInfo::lockId).collect(Collectors.joining(", "));
+        if (!lockIds.isEmpty()) {
+            sb.append("  locks: ").append(lockIds).append("\n");
+        }
+
+        Set<Long> visited = new HashSet<>();
+        visited.add(root.threadId());
+
+        record Frame(ThreadInfo thread, int depth) {
+        }
+        Deque<Frame> stack = new ArrayDeque<>();
+
+        // Push children in reverse order so first child is popped first
+        List<ThreadInfo> rootChildren = graph.children(root);
+        for (int i = rootChildren.size() - 1; i >= 0; i--) {
+            stack.push(new Frame(rootChildren.get(i), 1));
+        }
+
+        while (!stack.isEmpty()) {
+            Frame frame = stack.pop();
+            ThreadInfo current = frame.thread();
+            int depth = frame.depth();
+
+            if (!visited.add(current.threadId())) {
+                continue;
+            }
+
+            String indent = "  ".repeat(depth);
+            sb.append(indent);
+            sb.append(getCategoryPrefix(current)).append(" ").append(current.name());
+
+            current.stackTrace().stream()
+                    .filter(e -> !e.toString().contains("lock") && !e.className().contains("java.lang"))
+                    .findFirst()
+                    .ifPresent(frame1 -> sb.append(" ").append(frame1));
+
+            if (current.cpuTimeSec() != null) {
+                sb.append(String.format(Locale.US, ", CPU: %.2fs", current.cpuTimeSec()));
+            }
+
+            if (baseline != null) {
+                Instant firstSeen = firstSeenTimes.get(current.threadId());
+                if (firstSeen != null) {
+                    long timeDiff = Duration.between(baseline, firstSeen).getSeconds();
+                    if (timeDiff > 0) {
+                        sb.append(" [+").append(timeDiff).append("s]");
                     }
                 }
             }
 
-            // Track what lock this thread is waiting on
-            getWaitedOnLock(thread).ifPresent(lock -> threadWaitingOn.put(thread, lock.lockId()));
-        }
+            if (disappearedIds.contains(current.threadId())) {
+                sb.append(" [disappeared]");
+            }
 
-        // Build dependency graph
-        Map<ThreadInfo, Set<ThreadInfo>> dependencies = new HashMap<>();
-        Map<ThreadInfo, String> waitReasons = new HashMap<>();
+            sb.append("\n");
 
-        for (Map.Entry<ThreadInfo, String> entry : threadWaitingOn.entrySet()) {
-            ThreadInfo waiter = entry.getKey();
-            String lockId = entry.getValue();
-            ThreadInfo owner = lockOwners.get(lockId);
-
-            if (owner != null && !owner.equals(waiter)) {
-                dependencies.computeIfAbsent(waiter, k -> new HashSet<>()).add(owner);
-                waitReasons.put(waiter, lockId);
+            List<ThreadInfo> children = graph.children(current);
+            for (int i = children.size() - 1; i >= 0; i--) {
+                stack.push(new Frame(children.get(i), depth + 1));
             }
         }
-        if (dependencies.isEmpty()) {
-            return AnalyzerResult.ok();
-        }
-        return AnalyzerResult.ok(formatDependencyGraph(dependencies, waitReasons, latestDump));
     }
 
     public Optional<LockInfo> getWaitedOnLock(ThreadInfo thread) {
@@ -115,131 +496,6 @@ public class DependencyGraphAnalyzer extends BaseAnalyzer {
             case PARKING, WAITING_ON -> 1;
             default -> 5;
         };
-    }
-
-    private String formatDependencyGraph(Map<ThreadInfo, Set<ThreadInfo>> dependencies,
-                                        Map<ThreadInfo, String> waitReasons,
-                                        ThreadDump dump) {
-
-        StringBuilder sb = new StringBuilder();
-        sb.append("Thread Dependency Graph\n");
-        sb.append("======================\n\n");
-        sb.append("Shows which threads are waiting on locks held by other threads.\n");
-        sb.append("Format: [Category] Thread Name → [Category] Owner Thread Name (lock: <lockId>)\n\n");
-
-        // Sort by thread name for consistent output
-        List<Map.Entry<ThreadInfo, Set<ThreadInfo>>> sortedDeps = dependencies.entrySet().stream()
-            .sorted(Comparator.comparing(e -> e.getKey().name()))
-            .toList();
-
-        for (Map.Entry<ThreadInfo, Set<ThreadInfo>> entry : sortedDeps) {
-            ThreadInfo waiter = entry.getKey();
-            Set<ThreadInfo> owners = entry.getValue();
-
-            String waiterCategory = getCategoryPrefix(waiter);
-            String lockId = waitReasons.get(waiter);
-
-            for (ThreadInfo owner : owners) {
-                String ownerCategory = getCategoryPrefix(owner);
-
-                sb.append(waiterCategory)
-                  .append(" ")
-                  .append(waiter.name())
-                  .append("\n  → ")
-                  .append(ownerCategory)
-                  .append(" ")
-                  .append(owner.name());
-
-                if (lockId != null) {
-                    sb.append(" (lock: <").append(lockId).append(">)");
-                }
-
-                sb.append("\n");
-
-                // Show thread states
-                sb.append("     Waiter state: ").append(waiter.state());
-                if (waiter.cpuTimeSec() != null) {
-                    sb.append(String.format(Locale.US, ", CPU: %.2fs", waiter.cpuTimeSec()));
-                }
-                sb.append("\n");
-
-                sb.append("     Owner state:  ").append(owner.state());
-                if (owner.cpuTimeSec() != null) {
-                    sb.append(String.format(Locale.US, ", CPU: %.2fs", owner.cpuTimeSec()));
-                }
-                sb.append("\n\n");
-            }
-        }
-
-        // Add summary statistics
-        sb.append("\nSummary:\n");
-        sb.append("--------\n");
-        sb.append("Total waiting threads: ").append(dependencies.size()).append("\n");
-
-        int totalDependencies = dependencies.values().stream()
-            .mapToInt(Set::size)
-            .sum();
-        sb.append("Total dependencies: ").append(totalDependencies).append("\n");
-
-        // Find chains (threads waiting on threads that are also waiting)
-        Set<ThreadInfo> chainedThreads = new HashSet<>();
-        for (ThreadInfo waiter : dependencies.keySet()) {
-            if (dependencies.containsKey(waiter)) {
-                for (ThreadInfo owner : dependencies.get(waiter)) {
-                    if (dependencies.containsKey(owner)) {
-                        chainedThreads.add(waiter);
-                        chainedThreads.add(owner);
-                    }
-                }
-            }
-        }
-
-        if (!chainedThreads.isEmpty()) {
-            sb.append("\nDependency Chains Detected:\n");
-            sb.append("---------------------------\n");
-            sb.append("Threads involved in chains: ").append(chainedThreads.size()).append("\n");
-
-            // Show chains
-            Set<ThreadInfo> visited = new HashSet<>();
-            for (ThreadInfo start : dependencies.keySet()) {
-                if (!visited.contains(start)) {
-                    List<ThreadInfo> chain = buildChain(start, dependencies, visited);
-                    if (chain.size() > 1) {
-                        sb.append("\nChain: ");
-                        for (int i = 0; i < chain.size(); i++) {
-                            if (i > 0) sb.append(" → ");
-                            sb.append(getCategoryPrefix(chain.get(i)))
-                              .append(" ")
-                              .append(chain.get(i).name());
-                        }
-                        sb.append("\n");
-                    }
-                }
-            }
-        }
-
-        return sb.toString();
-    }
-
-    private List<ThreadInfo> buildChain(ThreadInfo start, Map<ThreadInfo, Set<ThreadInfo>> dependencies, Set<ThreadInfo> visited) {
-        List<ThreadInfo> chain = new ArrayList<>();
-        ThreadInfo current = start;
-        Set<ThreadInfo> chainVisited = new HashSet<>();
-
-        while (current != null && !chainVisited.contains(current)) {
-            chain.add(current);
-            visited.add(current);
-            chainVisited.add(current);
-
-            Set<ThreadInfo> owners = dependencies.get(current);
-            if (owners != null && !owners.isEmpty()) {
-                current = owners.iterator().next(); // Follow first owner
-            } else {
-                current = null;
-            }
-        }
-
-        return chain;
     }
 
     private String getCategoryPrefix(ThreadInfo thread) {

--- a/src/test/java/me/bechberger/jstall/analyzer/impl/DependencyGraphAnalyzerTest.java
+++ b/src/test/java/me/bechberger/jstall/analyzer/impl/DependencyGraphAnalyzerTest.java
@@ -142,9 +142,10 @@ class DependencyGraphAnalyzerTest {
         assertTrue(output.contains("Thread Dependency Graph"));
         assertTrue(output.contains("thread-2"));
         assertTrue(output.contains("thread-1"));
-        assertTrue(output.contains("→")); // Arrow showing dependency
-        assertTrue(output.contains("0x12345")); // Lock ID
-        assertTrue(output.contains("Total waiting threads: 1"));
+        assertTrue(output.contains("0x12345")); // Lock ID in root locks section
+        assertTrue(output.contains("1 potential bottleneck(s)"));
+        assertTrue(output.contains("1 blocked thread(s)")); // In tree root header
+        assertTrue(output.contains("Total blocked threads: 1"));
     }
 
     @Test
@@ -193,7 +194,7 @@ class DependencyGraphAnalyzerTest {
                 null
         );
 
-        // Thread 3 holds lock C
+        // Thread 3 holds lock C (root - owns but doesn't wait)
         ThreadInfo thread3 = new ThreadInfo(
                 "compute-thread-3",
                 3L,
@@ -228,16 +229,18 @@ class DependencyGraphAnalyzerTest {
         assertEquals(0, result.exitCode());
         String output = result.output();
 
-        // Should show dependencies and chain
+        // Should show the tree structure
         assertTrue(output.contains("Thread Dependency Graph"));
-        assertTrue(output.contains("Total waiting threads: 2"));
-        assertTrue(output.contains("Dependency Chains Detected"));
-        assertTrue(output.contains("Chain:"));
+        assertTrue(output.contains("Total blocked threads: 2"));
 
         // Should include category prefixes
         assertTrue(output.contains("[I/O Read]") || output.contains("I/O Read"));
         assertTrue(output.contains("[Network]") || output.contains("Network"));
         assertTrue(output.contains("[Computation]") || output.contains("Computation"));
+
+        // Root should be compute-thread-3 (only thread that owns locks but doesn't wait)
+        assertTrue(output.contains("compute-thread-3"));
+        assertTrue(output.contains("2 blocked thread(s)"));
     }
 
     @Test
@@ -319,8 +322,8 @@ class DependencyGraphAnalyzerTest {
         assertEquals(0, result.exitCode());
         String output = result.output();
 
-        // Should show both waiters depending on the same owner
-        assertTrue(output.contains("Total waiting threads: 2"));
+        // Should show both waiters blocked by the same owner
+        assertTrue(output.contains("Total blocked threads: 2"));
         assertTrue(output.contains("Total dependencies: 2"));
         assertTrue(output.contains("waiter-thread-1"));
         assertTrue(output.contains("waiter-thread-2"));
@@ -328,12 +331,14 @@ class DependencyGraphAnalyzerTest {
     }
 
     @Test
-    void testMultipleDumpsUsesLatest() {
+    void testMultipleDumpsAggregation() {
         DependencyGraphAnalyzer analyzer = new DependencyGraphAnalyzer();
 
-        // First dump: thread-1 holds lock, thread-2 waits on it
-        ThreadInfo oldThread1 = new ThreadInfo(
-                "old-owner",
+        Instant baseTime = Instant.parse("2024-01-01T00:00:00Z");
+
+        // First dump: owner holds lock, waiter blocked
+        ThreadInfo owner1 = new ThreadInfo(
+                "owner-thread",
                 1L,
                 null,
                 5,
@@ -342,17 +347,17 @@ class DependencyGraphAnalyzerTest {
                 1.0,
                 10.0,
                 List.of(
-                        new StackFrame("com.example.OldApp", "oldMethod", "OldApp.java", 100)
+                        new StackFrame("com.example.MyApp", "method1", "MyApp.java", 100)
                 ),
                 List.of(
-                        new LockInfo("0xOLD1", "java.lang.Object", LockInfo.LockOperation.LOCKED)
+                        new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.LOCKED)
                 ),
                 null,
                 null
         );
 
-        ThreadInfo oldThread2 = new ThreadInfo(
-                "old-waiter",
+        ThreadInfo waiter1 = new ThreadInfo(
+                "waiter-thread",
                 2L,
                 null,
                 5,
@@ -361,96 +366,85 @@ class DependencyGraphAnalyzerTest {
                 0.5,
                 10.0,
                 List.of(
-                        new StackFrame("com.example.OldApp", "oldMethod2", "OldApp.java", 200)
+                        new StackFrame("com.example.MyApp", "method2", "MyApp.java", 200)
                 ),
                 List.of(
-                        new LockInfo("0xOLD1", "java.lang.Object", LockInfo.LockOperation.WAITING_TO_LOCK)
+                        new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.WAITING_TO_LOCK)
                 ),
                 null,
                 null
         );
 
-        ThreadDump oldDump = new ThreadDump(
-                Instant.now().minusSeconds(10),
-                "Old Dump",
-                List.of(oldThread1, oldThread2),
+        ThreadDump dump1 = new ThreadDump(
+                baseTime,
+                "Dump 1",
+                List.of(owner1, waiter1),
                 null,
                 null,
                 null
         );
 
-        // Second dump (latest): different threads with different locks
-        ThreadInfo newThread1 = new ThreadInfo(
-                "new-owner",
-                3L,
+        // Second dump (5 seconds later): same pattern persists
+        ThreadInfo owner2 = new ThreadInfo(
+                "owner-thread",
+                1L,
                 null,
                 5,
                 false,
                 Thread.State.RUNNABLE,
                 2.0,
-                10.0,
+                15.0,
                 List.of(
-                        new StackFrame("java.sql.Connection", "executeQuery", "Connection.java", 100)
+                        new StackFrame("com.example.MyApp", "method1", "MyApp.java", 100)
                 ),
                 List.of(
-                        new LockInfo("0xNEW1", "java.lang.Object", LockInfo.LockOperation.LOCKED)
+                        new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.LOCKED)
                 ),
                 null,
                 null
         );
 
-        ThreadInfo newThread2 = new ThreadInfo(
-                "new-waiter",
-                4L,
+        ThreadInfo waiter2 = new ThreadInfo(
+                "waiter-thread",
+                2L,
                 null,
                 5,
                 false,
                 Thread.State.BLOCKED,
                 1.0,
-                10.0,
+                15.0,
                 List.of(
-                        new StackFrame("java.io.FileOutputStream", "write", "FileOutputStream.java", 200)
+                        new StackFrame("com.example.MyApp", "method2", "MyApp.java", 200)
                 ),
                 List.of(
-                        new LockInfo("0xNEW1", "java.lang.Object", LockInfo.LockOperation.WAITING_TO_LOCK)
+                        new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.WAITING_TO_LOCK)
                 ),
                 null,
                 null
         );
 
-        ThreadDump newDump = new ThreadDump(
-                Instant.now(),
-                "New Dump",
-                List.of(newThread1, newThread2),
+        ThreadDump dump2 = new ThreadDump(
+                baseTime.plusSeconds(5),
+                "Dump 2",
+                List.of(owner2, waiter2),
                 null,
                 null,
                 null
         );
 
-        // Analyze with both dumps
-        ThreadDumpSnapshot oldSnapshot = new ThreadDumpSnapshot(oldDump, "", null, null);
-        ThreadDumpSnapshot newSnapshot = new ThreadDumpSnapshot(newDump, "", null, null);
-        AnalyzerResult result = analyzer.analyze(ResolvedData.fromDumps(List.of(oldSnapshot, newSnapshot)), Map.of());
+        ThreadDumpSnapshot snapshot1 = new ThreadDumpSnapshot(dump1, "", null, null);
+        ThreadDumpSnapshot snapshot2 = new ThreadDumpSnapshot(dump2, "", null, null);
+        AnalyzerResult result = analyzer.analyze(ResolvedData.fromDumps(List.of(snapshot1, snapshot2)), Map.of());
 
         assertEquals(0, result.exitCode());
         String output = result.output();
 
-        // Should only show threads from the NEW dump
-        assertTrue(output.contains("new-waiter"), "Should contain new waiter thread");
-        assertTrue(output.contains("new-owner"), "Should contain new owner thread");
-        assertTrue(output.contains("0xNEW1"), "Should contain new lock ID");
-
-        // Should NOT show threads from the OLD dump
-        assertFalse(output.contains("old-waiter"), "Should NOT contain old waiter thread");
-        assertFalse(output.contains("old-owner"), "Should NOT contain old owner thread");
-        assertFalse(output.contains("0xOLD1"), "Should NOT contain old lock ID");
-
-        // Should show correct categories from new dump
-        assertTrue(output.contains("[Database]"), "Should categorize database thread");
-        assertTrue(output.contains("[I/O Write]"), "Should categorize I/O write thread");
-
-        // Should show correct summary
-        assertTrue(output.contains("Total waiting threads: 1"), "Should show 1 waiting thread from latest dump");
+        // Should aggregate: same root across 2 dumps
+        assertTrue(output.contains("owner-thread"), "Should contain root thread");
+        assertTrue(output.contains("waiter-thread"), "Should contain blocked thread");
+        assertTrue(output.contains("2 dump(s)"), "Should show persistence across 2 dumps");
+        assertTrue(output.contains("[+5s]"), "Should show time diff of 5 seconds for second dump");
+        assertTrue(output.contains("Bottleneck roots: 1"), "Should have 1 bottleneck root");
     }
 
     @Test
@@ -514,31 +508,90 @@ class DependencyGraphAnalyzerTest {
 
         // Check for expected output structure
         assertTrue(output.contains("Thread Dependency Graph"), "Should contain header");
-        assertTrue(output.contains("io-thread"), "Should contain waiting thread name");
-        assertTrue(output.contains("db-thread"), "Should contain owner thread name");
-        assertTrue(output.contains("→"), "Should contain dependency arrow");
+        assertTrue(output.contains("io-thread"), "Should contain blocked thread name");
+        assertTrue(output.contains("db-thread"), "Should contain root thread name");
         assertTrue(output.contains("0xDB01"), "Should contain lock ID");
 
         // Check for category prefixes
         assertTrue(output.contains("[Database]"), "Should contain Database category");
         assertTrue(output.contains("[I/O Write]"), "Should contain I/O Write category");
 
-        // Check for thread states
-        assertTrue(output.contains("Waiter state: BLOCKED"), "Should show waiter state");
-        assertTrue(output.contains("Owner state:  RUNNABLE"), "Should show owner state");
-
         // Check for CPU times
-        assertTrue(output.contains("CPU: 0.50s"), "Should show waiter CPU time");
-        assertTrue(output.contains("CPU: 5.00s"), "Should show owner CPU time");
+        assertTrue(output.contains("CPU: 0.50s"), "Should show blocked thread CPU time");
+        assertTrue(output.contains("CPU: 5.00s"), "Should show root thread CPU time");
 
         // Check for summary
         assertTrue(output.contains("Summary:"), "Should contain summary section");
-        assertTrue(output.contains("Total waiting threads: 1"), "Should show waiting thread count");
+        assertTrue(output.contains("Total blocked threads: 1"), "Should show blocked thread count");
         assertTrue(output.contains("Total dependencies: 1"), "Should show dependency count");
 
-        // Verify the full dependency line format
-        assertTrue(output.contains("[I/O Write] io-thread"), "Should show categorized waiter");
-        assertTrue(output.contains("[Database] db-thread"), "Should show categorized owner");
+        // Verify the categorized thread names in output
+        assertTrue(output.contains("[I/O Write] io-thread"), "Should show categorized blocked thread");
+        assertTrue(output.contains("[Database] db-thread"), "Should show categorized root thread");
+    }
+
+    @Test
+    void testDisappearingNodes() {
+        DependencyGraphAnalyzer analyzer = new DependencyGraphAnalyzer();
+
+        Instant baseTime = Instant.parse("2024-01-01T00:00:00Z");
+
+        // --- Dump 1: owner blocks waiter-A and waiter-B ---
+        ThreadInfo owner1 = new ThreadInfo(
+                "owner-thread", 1L, null, 5, false, Thread.State.RUNNABLE, 1.0, 10.0,
+                List.of(new StackFrame("com.example.MyApp", "method1", "MyApp.java", 100)),
+                List.of(new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.LOCKED)),
+                null, null
+        );
+        ThreadInfo waiterA1 = new ThreadInfo(
+                "waiter-A", 2L, null, 5, false, Thread.State.BLOCKED, 0.5, 10.0,
+                List.of(new StackFrame("com.example.MyApp", "methodA", "MyApp.java", 200)),
+                List.of(new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.WAITING_TO_LOCK)),
+                null, null
+        );
+        ThreadInfo waiterB1 = new ThreadInfo(
+                "waiter-B", 3L, null, 5, false, Thread.State.BLOCKED, 0.3, 10.0,
+                List.of(new StackFrame("com.example.MyApp", "methodB", "MyApp.java", 300)),
+                List.of(new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.WAITING_TO_LOCK)),
+                null, null
+        );
+        ThreadDump dump1 = new ThreadDump(
+                baseTime, "Dump 1", List.of(owner1, waiterA1, waiterB1), null, null, null
+        );
+
+        // --- Dump 2: waiter-B disappeared (got unblocked), only waiter-A remains ---
+        ThreadInfo owner2 = new ThreadInfo(
+                "owner-thread", 1L, null, 5, false, Thread.State.RUNNABLE, 2.0, 15.0,
+                List.of(new StackFrame("com.example.MyApp", "method1", "MyApp.java", 100)),
+                List.of(new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.LOCKED)),
+                null, null
+        );
+        ThreadInfo waiterA2 = new ThreadInfo(
+                "waiter-A", 2L, null, 5, false, Thread.State.BLOCKED, 1.0, 15.0,
+                List.of(new StackFrame("com.example.MyApp", "methodA", "MyApp.java", 200)),
+                List.of(new LockInfo("0xABC", "java.lang.Object", LockInfo.LockOperation.WAITING_TO_LOCK)),
+                null, null
+        );
+        ThreadDump dump2 = new ThreadDump(
+                baseTime.plusSeconds(5), "Dump 2", List.of(owner2, waiterA2), null, null, null
+        );
+
+        ThreadDumpSnapshot snapshot1 = new ThreadDumpSnapshot(dump1, "", null, null);
+        ThreadDumpSnapshot snapshot2 = new ThreadDumpSnapshot(dump2, "", null, null);
+        AnalyzerResult result = analyzer.analyze(
+                ResolvedData.fromDumps(List.of(snapshot1, snapshot2)), Map.of());
+
+        assertEquals(0, result.exitCode());
+        String output = result.output();
+
+        // waiter-B disappeared from dump2 but should still appear in the merged tree
+        assertTrue(output.contains("waiter-B"), "Disappeared thread should still appear in tree");
+        assertTrue(output.contains("[disappeared]"), "Disappeared thread should be annotated");
+        // waiter-A persists and should NOT be marked as disappeared
+        assertTrue(output.contains("waiter-A"), "Persistent thread should appear");
+        // The merged tree should count both blocked threads
+        assertTrue(output.contains("Total blocked threads: 2"),
+                "Should count both persistent and disappeared threads");
     }
 
     @Test


### PR DESCRIPTION
This pull request rewrites `DependencyGraphAnalyzer` to build lock dependency graphs across all dumps, aggregate by root thread, detect disappearing nodes, and render a tree output.
It replaces the flat waiter → owner format with a bottleneck graph that shows the full blocking hierarchy across all dumps.

- Multi-dump analysis
- Lock dependency building
- Root discovery
- Graph construction
- Fold graphs cross-dump
- Handling of disappearing nodes
- Tree rendering

Existing tests were updated and new test added.